### PR TITLE
update psutil to fix python 3.11 compatibility

### DIFF
--- a/app/patches/requirements.txt
+++ b/app/patches/requirements.txt
@@ -2,5 +2,5 @@ falcon==3.1.0
 falcon-multipart==0.2.0
 gunicorn==20.1.0
 mem-edit==0.6
-psutil==5.9.1
+psutil==5.9.6
 typing==3.7.4.3


### PR DESCRIPTION
As described in issue #4 the installation on SteamOS is broken since Python has been updated to Python 3.11 on SteamOS 3.5.

Updating the psutil package to latest version fix this problem.

Closes #4.