### PR TITLE
Add support for 8 BYTE value search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Memory Hack is a cross-platform memory editor with a web based front-end.
 
 ## Features
 
-- Memory searcher that can find 1, 2, 4 byte values as well as floating point values.
+- Memory searcher that can find 1, 2, 4, 8 byte values as well as floating point values.
 - Unknown value scanner to search for values not represented as numeric (life bars, timers, etc...)
 - AOB (Array of bytes) heap scanner to help narrow down dynamic values.
 - Code list that can store memory addresses and AOB values for reuse.

--- a/app/helpers/aob_walk.py
+++ b/app/helpers/aob_walk.py
@@ -228,6 +228,8 @@ class AOBWalk:
                 val = value_to_bytes(val, 2)
             elif tp == AOBWalk.BYTE_4:
                 val = value_to_bytes(val, 4)
+            elif tp == AOBWalk.BYTE_8:
+                val = value_to_bytes(val, 8)
             else: #better be a hex string
                 val = value_to_bytes(val, 0)
         except Exception as e:

--- a/app/resources/aob.html
+++ b/app/resources/aob.html
@@ -64,6 +64,7 @@
             <option value="byte_1">BYTE</option>
             <option value="byte_2">2 BYTES</option>
             <option value="byte_4" selected>4 BYTES</option>
+            <option value="byte_8">8 BYTES</option>
           </select>
         </ons-col>
         <ons-col align="center" width="20%" class="col ons-col-inner"><ons-button id="aob_paste_button" modifier="material--flat" onclick="document.clipboard.paste(aob, 'aob')"><ons-icon style="color:#777;" size="28px" icon="md-paste"></ons-icon></ons-button></ons-col>

--- a/app/resources/search.html
+++ b/app/resources/search.html
@@ -38,6 +38,7 @@
             <option value="byte_1">BYTE</option>
             <option value="byte_2">2 BYTES</option>
             <option value="byte_4" selected>4 BYTES</option>
+            <option value="byte_8">8 BYTES</option>
             <option value="float">FLOAT</option>
             <option value="array">ARRAY</option>
           </select>

--- a/app/resources/static/aob.js
+++ b/app/resources/static/aob.js
@@ -1142,12 +1142,12 @@
                 case 'byte_2':
                     value_valid = (n >= -2<<14 && n < 2<<15)
                     break
-                case 'byte_4':
-                    value_valid = (n >= -2<<30 && n < 2<<31)
-                    break
-                case 'byte_8':
-                    value_valid = (n >= -2<<62 && n < 2<<63)
-                    break
+                    case 'byte_4':
+                        value_valid = (n >= -2<<30 && n < 2**32)
+                        break
+                    case 'byte_8':
+                        value_valid = (n >= -(2**63) && n < 2**64)
+                        break
             }
         }
     }

--- a/app/resources/static/aob.js
+++ b/app/resources/static/aob.js
@@ -1143,7 +1143,10 @@
                     value_valid = (n >= -2<<14 && n < 2<<15)
                     break
                 case 'byte_4':
-                    value_valid = (n >= -2<<30 && n < 2**32)
+                    value_valid = (n >= -2<<30 && n < 2<<31)
+                    break
+                case 'byte_8':
+                    value_valid = (n >= -2<<62 && n < 2<<63)
                     break
             }
         }

--- a/app/resources/static/codelist.js
+++ b/app/resources/static/codelist.js
@@ -867,6 +867,7 @@
                         <option value="byte_1">BYTE</option>
                         <option value="byte_2">2 BYTES</option>
                         <option value="byte_4" selected>4 BYTES</option>
+                        <option value="byte_8">8 BYTES</option>
                         <option value="float">FLOAT</option>
                      </select>`,
         'create': index => {

--- a/app/resources/static/search.js
+++ b/app/resources/static/search.js
@@ -1020,10 +1020,10 @@
                         value_valid = (n >= -2<<14 && n < 2<<15)
                         break
                     case 'byte_4':
-                        value_valid = (n >= -2<<30 && n < 2<<31)
+                        value_valid = (n >= -2<<30 && n < 2**32)
                         break
                     case 'byte_8':
-                        value_valid = (n >= -2<<62 && n < 2<<63)
+                        value_valid = (n >= -(2**63) && n < 2**64)
                         break
                 }
             }

--- a/app/resources/static/search.js
+++ b/app/resources/static/search.js
@@ -393,6 +393,7 @@
                     sel_search_size.find('option[value="byte_1"]').show()
                     sel_search_size.find('option[value="byte_2"]').show()
                     sel_search_size.find('option[value="byte_4"]').show()
+                    sel_search_size.find('option[value="byte_8"]').show()
                     sel_search_size.find('option[value="float"]').show()
                     sel_search_size.find('option[value="array"]').show()
                     sel_search_size.find('option[value="byte_4"]').prop('selected', true)
@@ -423,6 +424,7 @@
                     sel_search_size.find('option[value="byte_1"]').hide()
                     sel_search_size.find('option[value="byte_2"]').hide()
                     sel_search_size.find('option[value="byte_4"]').hide()
+                    sel_search_size.find('option[value="byte_8"]').hide()
                     sel_search_size.find('option[value="float"]').hide()
                     sel_search_size.find('option[value="array"]').hide()
                     sel_search_size.find('option[value="array"]').prop('selected', true)
@@ -430,6 +432,7 @@
                     sel_search_size.find('option[value="byte_1"]').show()
                     sel_search_size.find('option[value="byte_2"]').show()
                     sel_search_size.find('option[value="byte_4"]').show()
+                    sel_search_size.find('option[value="byte_8"]').show()
                     sel_search_size.find('option[value="float"]').show()
                     sel_search_size.find('option[value="array"]').hide()
                     sel_search_size.find('option[value="byte_4"]').prop('selected', true)
@@ -451,6 +454,7 @@
                 sel_search_size.find('option[value="byte_1"]').show()
                 sel_search_size.find('option[value="byte_2"]').show()
                 sel_search_size.find('option[value="byte_4"]').show()
+                sel_search_size.find('option[value="byte_8"]').show()
                 sel_search_size.find('option[value="float"]').show()
                 sel_search_size.find('option[value="array"]').hide()
                 sel_search_size.find('option[value="byte_4"]').prop('selected', true)
@@ -818,6 +822,7 @@
                 sel_search_size.find('option[value="byte_1"]').show()
                 sel_search_size.find('option[value="byte_2"]').show()
                 sel_search_size.find('option[value="byte_4"]').show()
+                sel_search_size.find('option[value="byte_8"]').show()
                 sel_search_size.find('option[value="float"]').show()
                 sel_search_size.find('option[value="array"]').hide()
                 switch_search_aligned.removeAttr('disabled')
@@ -1015,7 +1020,10 @@
                         value_valid = (n >= -2<<14 && n < 2<<15)
                         break
                     case 'byte_4':
-                        value_valid = (n >= -2<<30 && n < 2**32)
+                        value_valid = (n >= -2<<30 && n < 2<<31)
+                        break
+                    case 'byte_8':
+                        value_valid = (n >= -2<<62 && n < 2<<63)
                         break
                 }
             }


### PR DESCRIPTION
It seems that the underlying implementation of memory editing in python was already supporting 8 bytes values. However the UI was not supporting them.

This PR adds the option to select 8 bytes as a size in the UI.

I tested my changes running BG3 on Steam Deck and it was able to find a 8 byte value.